### PR TITLE
add class checking in onRestoreInstanceState

### DIFF
--- a/library/src/main/java/com/hugocastelani/waterfalltoolbar/WaterfallToolbar.kt
+++ b/library/src/main/java/com/hugocastelani/waterfalltoolbar/WaterfallToolbar.kt
@@ -245,6 +245,11 @@ open class WaterfallToolbar : CardView {
      * @param state The frozen state that had previously been returned by onSaveInstanceState()
      */
     override fun onRestoreInstanceState(state: Parcelable) {
+        if (state !is SavedState) {
+            super.onRestoreInstanceState(state)
+            return
+        }
+
         val savedState = state as SavedState
         super.onRestoreInstanceState(savedState.superState)
 

--- a/library/src/main/java/com/hugocastelani/waterfalltoolbar/WaterfallToolbar.kt
+++ b/library/src/main/java/com/hugocastelani/waterfalltoolbar/WaterfallToolbar.kt
@@ -245,21 +245,21 @@ open class WaterfallToolbar : CardView {
      * @param state The frozen state that had previously been returned by onSaveInstanceState()
      */
     override fun onRestoreInstanceState(state: Parcelable) {
-        if (state !is SavedState) {
+        if (state is SavedState) {
+            super.onRestoreInstanceState(state.superState)
+
+            // setting card elevation doesn't work until view is created
+            post {
+                // it's safe to use "!!" here, since savedState will
+                // always store values properly set in onSaveInstanceState()
+                cardElevation = state.elevation!!.toFloat()
+                orthodoxPosition = state.orthodoxPosition!!
+                realPosition = state.realPosition!!
+            }
+            
+        } else  {
+            
             super.onRestoreInstanceState(state)
-            return
-        }
-
-        val savedState = state as SavedState
-        super.onRestoreInstanceState(savedState.superState)
-
-        // setCardElevation() doesn't work until view is created
-        post {
-            // it's safe to use "!!" here, since savedState will
-            // always store values properly set in onSaveInstanceState()
-            cardElevation = savedState.elevation!!.toFloat()
-            orthodoxPosition = savedState.orthodoxPosition!!
-            realPosition = savedState.realPosition!!
         }
     }
 

--- a/library/src/main/java/com/hugocastelani/waterfalltoolbar/WaterfallToolbar.kt
+++ b/library/src/main/java/com/hugocastelani/waterfalltoolbar/WaterfallToolbar.kt
@@ -257,7 +257,7 @@ open class WaterfallToolbar : CardView {
                 realPosition = state.realPosition!!
             }
             
-        } else  {
+        } else {
             
             super.onRestoreInstanceState(state)
         }


### PR DESCRIPTION
Hello @HugoCastelani ! thank you for cool library. the lib crashes during restore in "don't keep activities" mode, because of class cast exception. to avoid this we need to add checking for the right class